### PR TITLE
Bug Fix: Remediate Unwanted Click Behavior

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,8 @@ interface Photo {
   id: number,
   src: { medium: string },
   isClicked?: boolean,
-  isMatched?: boolean
+  isMatched?: boolean,
+  isLocked?: boolean,
 }
 
 const clickedCards = ref([])
@@ -46,6 +47,7 @@ const imageList = (urlList: Array<Photo>): Array<Photo> => {
       src: src,
       isClicked: false,
       isMatched: false,
+      isLocked: false,
     }
   })
 }

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -6,6 +6,7 @@ interface Photo {
   src: { medium: string },
   isClicked?: boolean,
   isMatched?: boolean,
+  isLocked?: boolean,
 }
 
 const props = defineProps({
@@ -13,6 +14,16 @@ const props = defineProps({
   clickedCards: Array<Photo>,
   shuffledPhotos: Array<Photo>,
 })
+
+const lockSetter = (value: boolean) => {
+  if (props.shuffledPhotos === undefined) {
+    return
+  }
+
+  props.shuffledPhotos.forEach((photo:Photo) => {
+    photo.isLocked = value
+  })
+}
 
 const flipCard = (event:Event) => {
   if (props.shuffledPhoto === undefined) {
@@ -43,7 +54,7 @@ const checkForMatch = () => {
     return
   }
 
-  if (props.clickedCards.length === 2)
+  if (props.clickedCards.length >= 2)
     if (props.clickedCards[0].src.medium === props.clickedCards[1].src.medium) {
       // Cards stay face up
       cardMatcher(props.clickedCards[0].id, props.clickedCards[1].id)
@@ -56,6 +67,7 @@ const checkForMatch = () => {
 }
 
 const cardResetter = (cardId1: number, cardId2: number) => {
+  lockSetter(true)
   if (props.shuffledPhotos === undefined) {
     return
   }
@@ -68,9 +80,11 @@ const cardResetter = (cardId1: number, cardId2: number) => {
       setTimeout(() => {photo.isClicked = false}, 1800)
     }
   })
+  setTimeout(() => {lockSetter(false)}, 1800)
 }
 
 const cardMatcher = (cardId1: number, cardId2: number) => {
+  lockSetter(true)
   if (props.shuffledPhotos === undefined) {
     return
   }
@@ -81,16 +95,17 @@ const cardMatcher = (cardId1: number, cardId2: number) => {
       photo.isMatched = true
     }
   })
+  lockSetter(false)
 }
 </script>
 
 <template>
-  <section className="border-black border-2 h-full w-full rounded-lg" @click="flipCard">
-    <img v-if="props.shuffledPhoto?.isClicked" className="h-full w-full rounded-lg"
+  <button className="border-black border-2 h-full w-full rounded-lg" :disabled="props.shuffledPhoto?.isLocked" @click="flipCard">
+    <img v-if="props.shuffledPhoto?.isClicked" className="h-full w-full rounded-lg cursor-default"
     :src="shuffledPhoto?.src.medium" :alt="props.shuffledPhoto?.id">
-    <img v-else-if="props.shuffledPhoto?.isMatched" className="h-full w-full rounded-lg"
+    <img v-else-if="props.shuffledPhoto?.isMatched" className="h-full w-full rounded-lg cursor-default"
     :src="shuffledPhoto?.src.medium" :alt="props.shuffledPhoto?.id">
     <img v-else className="h-full w-full rounded-lg hover:mt-[-5px] hover:shadow-md
      hover:border-sky-700 hover:shadow-cyan-500/50 cursor-pointer" :src="cardBlue" :alt="props.shuffledPhoto?.id">
-  </section> 
+  </button>
 </template>

--- a/src/components/CardsContainer.vue
+++ b/src/components/CardsContainer.vue
@@ -6,6 +6,7 @@ interface Photo {
   src: { medium: string },
   isClicked?: boolean,
   isMatched?: boolean,
+  isLocked?: boolean,
 }
 
 defineProps({


### PR DESCRIPTION
# Pull Request

## Category: [Fix]

## Description:
This PR is a bugfix for unwanted behavior outlined in https://github.com/Ant-Shell/image-match-game/issues/14, which does the following:
- Add an `isLocked` property to each image
- Locks the click action on each card (button) while doing comparison of two cards for a potential match
- Additional cards are no longer clickable if two cards are face up for comparison
- Cards will become clickable again once non-matching cards are flipped face down, or if matching cards have been detected

https://github.com/Ant-Shell/image-match-game/issues/14 can now be closed.

## Next Steps:
- Planning to fix styling, much improvement can be made in the way of responsiveness
- Add additional nice-to-have features

## Any other comments or questions:
- Progress is good!