### PR TITLE
Bug Fix: Fix Unwanted Click Behavior

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -21,7 +21,11 @@ const lockSetter = (value: boolean) => {
   }
 
   props.shuffledPhotos.forEach((photo:Photo) => {
-    photo.isLocked = value
+    if (photo.isMatched) {
+      photo.isLocked = true
+    } else {
+      photo.isLocked = value
+    }
   })
 }
 


### PR DESCRIPTION
# Pull Request

## Category: [Fix] 

## Description:
This PR refactors the `lockSetter` function to lock card if it has already been matched. This update should now fix the unwanted click behavior that was observed in https://github.com/Ant-Shell/image-match-game/issues/14 and partially remediated in https://github.com/Ant-Shell/image-match-game/pull/15

## Next Steps:
- Do some additional refactoring, then focus on additional styling and visual features

## Any other comments or questions:
N/A