### PR TITLE
Feature: Reimplement Fetch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,11 @@ const cardShuffler = (cardList: Array<Card>): Array<Card> => {
 }
 
 const gameResetter = () => {
-  shuffledCards.value = cardShuffler(cardList(images.value))
+  if (images.value.length) {
+    shuffledCards.value = cardShuffler(cardList(images.value))
+  } else {
+    shuffledCards.value = cardShuffler(cardList(photos))
+  }
   matchCount.value = 0
   moveCount.value = 0
   gameWon.value = false

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,31 +1,11 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Photo } from 'pexels';
+import { getImages } from './utils/apiCalls'
 import WinnerModal from './components/WinnerModal.vue'
 import Heading from './components/Heading.vue'
 import CardsContainer from './components/CardsContainer.vue'
-import { ref } from 'vue'
 import photos from './data/imageData'
-// import { createClient, ErrorResponse, Photos, Photo } from 'pexels';
-
-// const API_KEY = import.meta.env.VITE_APP_API_KEY
-// const client = createClient(API_KEY)
-
-// May need to adjust downstream, or isolate the string somehow:
-// const images = ref<Array<Photo> | string>() 
-
-// Get images using The Pexels Javascript library
-// const getImages = async () => {
-//   await client.photos.curated({ per_page: 8 }).then(photos => {
-//     if ((<Photos>photos).photos) {
-//       const imageList = (<Photos>photos)
-//       images.value = imageList.photos
-//     } else {
-//       const error = (<ErrorResponse>photos)
-//       console.log(error.error)
-//       images.value = error.error
-//     }
-//   })
-// }
-// getImages()
 
 interface Card {
   id: number,
@@ -40,6 +20,21 @@ const clickedCards = ref<Array<Card>>([])
 const matchCount = ref<number>(0)
 const moveCount = ref<number>(0)
 const gameWon = ref<boolean>(false)
+const images = ref<Array<Photo>>([])
+const errorMessage = ref<string>("")
+const shuffledCards = ref<Array<Card>>([])
+
+onMounted(() =>
+  getImages()
+  .then((data) => {
+    images.value = data.photos
+    shuffledCards.value = cardShuffler(cardList(images.value))
+  })
+  .catch((error) => {
+    errorMessage.value = `${error}. Using default cards.`
+    shuffledCards.value = cardShuffler(cardList(photos))
+  })
+)
 
 const cardList = (cards: Array<Card>): Array<Card> => {
   return cards?.reduce((acc:Array<Card>, curr:Card): Array<Card> => {
@@ -63,10 +58,8 @@ const cardShuffler = (cardList: Array<Card>): Array<Card> => {
   return cardList.sort(() => Math.random() - 0.5)
 }
 
-const shuffledCards = ref<Array<Card>>(cardShuffler(cardList(photos)))
-
 const gameResetter = () => {
-  shuffledCards.value = cardShuffler(cardList(photos))
+  shuffledCards.value = cardShuffler(cardList(images.value))
   matchCount.value = 0
   moveCount.value = 0
   gameWon.value = false

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,10 @@ const errorMessage = ref<string>("")
 const shuffledCards = ref<Array<Card>>([])
 
 onMounted(() =>
+  imageFetcher()
+)
+
+const imageFetcher = () => {
   getImages()
   .then((data) => {
     images.value = data.photos
@@ -34,7 +38,7 @@ onMounted(() =>
     errorMessage.value = `${error}. Using default cards.`
     shuffledCards.value = cardShuffler(cardList(photos))
   })
-)
+}
 
 const cardList = (cards: Array<Card>): Array<Card> => {
   return cards?.reduce((acc:Array<Card>, curr:Card): Array<Card> => {
@@ -68,6 +72,13 @@ const gameResetter = () => {
   moveCount.value = 0
   gameWon.value = false
 }
+
+const startNewGame = () => {
+  imageFetcher()
+  matchCount.value = 0
+  moveCount.value = 0
+  gameWon.value = false
+ }
 
 const determineWinner = () => {
   if (matchCount.value === (shuffledCards.value.length / 2)) {
@@ -157,7 +168,7 @@ const cardMatcher = (cardPosition1: number, cardPosition2: number) => {
 <template>
   <main class="h-screen w-full flex flex-col md:flex-row md:justify-center bg-cover bg-top relative"
     style="background-image: url(./src/assets/sebastian-unrau-sp-p7uuT0tw-unsplash.jpg)">
-      <WinnerModal v-bind:gameWon="gameWon" :gameResetter="gameResetter"/>
+      <WinnerModal v-bind:gameWon="gameWon" :startNewGame="startNewGame"/>
       <Heading v-bind:matchCount="matchCount" v-bind:moveCount="moveCount" :gameResetter="gameResetter" />
       <CardsContainer v-bind:shuffledCards="shuffledCards" :addCard="addCard" />
   </main>

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,16 +16,16 @@ interface Card {
   isLocked?: boolean,
 }
 
+const images = ref<Array<Photo>>([])
+const shuffledCards = ref<Array<Card>>([])
 const clickedCards = ref<Array<Card>>([])
 const matchCount = ref<number>(0)
 const moveCount = ref<number>(0)
 const gameWon = ref<boolean>(false)
-const images = ref<Array<Photo>>([])
 const errorMessage = ref<string>("")
-const shuffledCards = ref<Array<Card>>([])
 
 onMounted(() =>
-  imageFetcher()
+  startNewGame()
 )
 
 const imageFetcher = () => {

--- a/src/components/Heading.vue
+++ b/src/components/Heading.vue
@@ -5,6 +5,11 @@ const props = defineProps({
   moveCount: Number,
   gameResetter: Function,
 })
+
+const resetGame = () => {
+  props.gameResetter?.()
+}
+
 </script>
 
 <template>
@@ -14,7 +19,7 @@ const props = defineProps({
       <h2>Total Moves: {{ props.moveCount }}</h2>
     </div>
     <button class="w-28 md:w-36 h-10 md:h-12 border-2 bg-[#374F2F] border-[#304529] text-white md:text-xl lg:text-2xl
-    hover:bg-[#4A6741] rounded-md" @click="props.gameResetter">
+    hover:bg-[#4A6741] rounded-md" @click="resetGame">
       Reset Game
     </button>
   </header>

--- a/src/components/WinnerModal.vue
+++ b/src/components/WinnerModal.vue
@@ -2,11 +2,11 @@
 
 const props = defineProps({
   gameWon: Boolean,
-  gameResetter: Function,
+  startNewGame: Function,
 })
 
 const restartGame = () => {
-  props.gameResetter?.()
+  props.startNewGame?.()
 }
 
 </script>

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -10,7 +10,6 @@ const getImages = async (): Promise<Photos> => {
       return response as Photos;
     } else {
       const errorMessage = response
-      console.error('Error fetching photos:', errorMessage.error);
       throw new Error(errorMessage.error);
     }
   } catch (error) {

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -1,0 +1,22 @@
+import { createClient, Photos } from 'pexels';
+
+const API_KEY = import.meta.env.VITE_APP_API_KEY;
+const client = createClient(API_KEY);
+
+const getImages = async (): Promise<Photos> => {
+  try {
+    const response = await client.photos.curated({ per_page: 8 });
+    if ('photos' in response) {
+      return response as Photos;
+    } else {
+      const errorMessage = response
+      console.error('Error fetching photos:', errorMessage.error);
+      throw new Error(errorMessage.error);
+    }
+  } catch (error) {
+    console.error("Failed to fetch curated photos:", error);
+    throw error;
+  }
+};
+
+export { getImages };


### PR DESCRIPTION
# Pull Request

## Category: [Feature]

## Description:
This PR does the following:
- Relocate fetch logic into `src/utils/apiCalls.ts`
- Add new functions in `src/App.vue`
  - `imageFetcher`
  - `startNewGame`
- Pass updated props
- Update imports

Player should now be able to:
- Reset game, which resets move and match count, but keeps the same cards (images)
- Start a new game upon winning, which resets move and match count, plus fetches new cards (images) when available/updated in the Pexels API

## Next Steps:
- User feedback/message if/when fetch fails
- PageLoad component, or something similar

## Any other comments or questions:
- Error handling should be good, but more testing will be needed